### PR TITLE
Offset models

### DIFF
--- a/demos/rossmann/demo.ipynb
+++ b/demos/rossmann/demo.ipynb
@@ -108,6 +108,74 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "a = guac.data.df.sort_values(['Store', 'Date'])[:10]\n",
+    "a = a[['Store', 'Date', 'Sales']]\n",
+    "a = a.iloc[[0, 3, 5 ,6]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a['index'] = 1\n",
+    "a['level_0'] = 1\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a.reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pd.DateOffset(days=1).kwds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = pd.DataFrame({'a': [1,None,3]})\n",
+    "b = pd.DataFrame({'a': [1,2,3], 'b': [0,0,0]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a.append(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a[a.a < 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/guacml/guacml.py
+++ b/guacml/guacml.py
@@ -87,17 +87,20 @@ class GuacMl:
                             .format(date_split_col, self.data.df.columns))
         if series_key_cols is None:
             series_key_cols = ['guac_time_series_key']
-            # this hack makes the whole code that groups by time series key reusable for the case of a single time series.
+            # this hack makes the whole code that groups by time series key
+            # reusable for the case of a single time series.
             # it's omitted in the metadata
             self.data.df['guac_time_series_key'] = True
         elif not isinstance(series_key_cols, list):
             series_key_cols = [series_key_cols]
         for key_col in series_key_cols:
             if key_col not in self.data.df.columns:
-                raise Exception('The time series key column {} was not in the columns of the data set {}.'
+                raise Exception('The time series key column {} was not in the'
+                                ' columns of the data set {}.'
                                 .format(key_col, self.data.df.columns))
         if not isinstance(prediction_length, int) and prediction_length > 0:
-            raise Exception('Prediction length must be positive integer, but was {}'.format(prediction_length))
+            raise Exception('Prediction length must be positive integer, but was {}'
+                            .format(prediction_length))
 
         rt_conf = self.config['run_time']
         ts_conf = rt_conf['time_series']

--- a/guacml/guacml.py
+++ b/guacml/guacml.py
@@ -73,7 +73,15 @@ class GuacMl:
         self.model_results = None
         self.runner = None
 
-    def make_time_series(self, date_split_col, series_key_cols=None, prediction_length=1):
+    def make_time_series(self, date_split_col, series_key_cols=None, prediction_length=1,
+                         frequency=pd.DateOffset(days=1), n_offset_models=1):
+        """
+        :param date_split_col: Name of the date column.
+        :param series_key_cols: If many time series, these are the keys for the time series
+        :param prediction_length: Time steps an individual model should predict into the future
+        :param frequency: Frequency of the time series
+        :param n_offset_models: Number of models for predicting further into the future
+        """
         if date_split_col not in self.data.df.columns:
             raise Exception('The date_split_col {} was not in the columns of the data set {}.'
                             .format(date_split_col, self.data.df.columns))
@@ -92,10 +100,13 @@ class GuacMl:
             raise Exception('Prediction length must be positive integer, but was {}'.format(prediction_length))
 
         rt_conf = self.config['run_time']
+        ts_conf = rt_conf['time_series']
         rt_conf['is_time_series'] = True
-        rt_conf['time_series']['date_split_col'] = date_split_col
-        rt_conf['time_series']['series_key_cols'] = series_key_cols
-        rt_conf['time_series']['prediction_length'] = prediction_length
+        ts_conf['date_split_col'] = date_split_col
+        ts_conf['series_key_cols'] = series_key_cols
+        ts_conf['prediction_length'] = prediction_length
+        ts_conf['frequency'] = frequency
+        ts_conf['n_offset_models'] = n_offset_models
 
         # ToDo: this is duplicated from the guac constructor
         tree_builder = TreeBuilder(self.config, self.logger)

--- a/guacml/metrics/root_mean_squared_log_error.py
+++ b/guacml/metrics/root_mean_squared_log_error.py
@@ -5,11 +5,14 @@ from guacml.metrics.base_eval_metric import BaseEvalMetric
 
 def _row_error(truth, prediction):
     if (truth == 0).any():
-        raise ValueError('Can not compute rmsle, when there are zeros in the target column.')
+        raise ValueError('Can not compute rmsle, '
+                         'when there are zeros in the target column.')
     if (truth < 0).any():
-        raise ValueError('Can not compute rmsle, when there are negative values in the target column.')
+        raise ValueError('Can not compute rmsle, '
+                         'when there are negative values in the target column.')
     if (prediction < 0).any():
-        raise ValueError('Can not compute rmsle, when there are negative values in the predictions.')
+        raise ValueError('Can not compute rmsle, '
+                         'when there are negative values in the predictions.')
 
     return (np.log(np.maximum(prediction, 0)) - np.log(truth)) ** 2
 

--- a/guacml/models/random_forest.py
+++ b/guacml/models/random_forest.py
@@ -46,7 +46,7 @@ class RandomForest(BaseModel):
         if self.problem_type == ProblemType.BINARY_CLAS:
             prediction = self.model.predict_proba(x)[:, 1]
         elif self.problem_type == ProblemType.REGRESSION:
-            prediction =  self.model.predict(x)
+            prediction = self.model.predict(x)
         else:
             raise NotImplementedError('Problem type {0} not implemented'.format(self.problem_type))
 

--- a/guacml/plots.py
+++ b/guacml/plots.py
@@ -47,7 +47,7 @@ class Plots:
 
         n_key_combs = keys_sample.shape[0]
         fig, axes = plt.subplots(n_key_combs, 2, figsize=(12, 3 * n_key_combs),
-                     gridspec_kw={'width_ratios':[5, 2]})
+                                 gridspec_kw={'width_ratios': [5, 2]})
 
         for i, pair in enumerate(keys_sample.iterrows()):
             if len(axes.shape) == 1:
@@ -109,30 +109,33 @@ class Plots:
         model_result = self.model_results[model_name]
         if not self.run_time_config['is_time_series']:
             if self.problem_type == ProblemType.BINARY_CLAS:
-                return predictions_vs_actual_classification(model_result, model_name, n_bins, **kwargs)
+                return predictions_vs_actual_classification(model_result,
+                                                            model_name,
+                                                            n_bins,
+                                                            **kwargs)
             elif self.problem_type == ProblemType.REGRESSION:
                 return predictions_vs_actual_regression(model_result, model_name, **kwargs)
             else:
                 raise Exception('Not implemented for problem type ' + self.problem_type)
         else:
-            self.predictions_vs_actual_time_series(model_result, model_name, self.run_time_config, **kwargs)
+            self.predictions_vs_actual_time_series(model_result,
+                                                   model_name,
+                                                   self.run_time_config,
+                                                   **kwargs)
 
     def predictions_vs_actual_time_series(self, model_results, model_name,  size=6, **kwargs):
         date_col = self.run_time_config['time_series']['date_split_col']
         series_key_cols = self.run_time_config['time_series']['series_key_cols']
         keys_sample = self._get_time_series_key_sample()
-
         holdout = model_results.holdout_data
-        target = model_results.target
-
         n_key_combs = keys_sample.shape[0]
         fig, axes = plt.subplots(n_key_combs, 1, figsize=(12, 3 * n_key_combs))
 
         for i, pair in enumerate(keys_sample.iterrows()):
             if isinstance(axes, np.ndarray):
-                ax= axes[i]
+                ax = axes[i]
             else:
-                ax= axes
+                ax = axes
 
             keys = pair[1]
             time_series = holdout[(holdout[series_key_cols] == keys).all(axis=1)]
@@ -204,8 +207,3 @@ def predictions_vs_actual_regression(model_results, model_name, size=6, bins=Non
     elif bins == 'log':
         color_bar.set_label('log_10(count)')
     return grid
-
-
-
-
-

--- a/guacml/preprocessing/column_cleaner.py
+++ b/guacml/preprocessing/column_cleaner.py
@@ -8,4 +8,5 @@ class ColumnCleaner(BaseStep):
                 col = col_desc.col_name
                 data.df[col].replace('', None, inplace=True)
                 col_desc.n_blank = 0
-                self.logger.info('Replaced %d blank values with None for column %s', col_desc.n_blanks, col)
+                self.logger.info('Replaced %d blank values with None for column %s',
+                                 col_desc.n_blanks, col)

--- a/guacml/preprocessing/feature_generation/historical_medians.py
+++ b/guacml/preprocessing/feature_generation/historical_medians.py
@@ -5,12 +5,27 @@ import pandas as pd
 
 class HistoricalMedians(BaseStep):
 
+    def __init__(self, config):
+        super().__init__(config)
+        self.run_time_config = config['run_time']
+        self.n_offset_models = self.run_time_config['time_series']['n_offset_models']
+
     def execute_inplace(self, data):
-        run_time_config = self.config['run_time']
-        date_split_col = run_time_config['time_series']['date_split_col']
-        series_key_cols = run_time_config['time_series']['series_key_cols']
-        prediction_length = run_time_config['time_series']['prediction_length']
-        target = run_time_config['target']
+        """
+        When we want to predict x time steps into the future, we can not include the last
+        x-1 time steps into the median, because they will be unknown for the test set.
+        But we also want to have recent time steps if we don't predict far in the future,
+        as they make prediction better.
+        Solution: Train several models, some for predicting the closer time steps, some
+        for the time steps further out. The number of models is called n_offset_models.
+        """
+        ts_conf = self.run_time_config['time_series']
+        date_split_col = ts_conf['date_split_col']
+        series_key_cols = ts_conf['series_key_cols']
+        prediction_length = ts_conf['prediction_length']
+
+        target = self.run_time_config['target']
+
         df = data.df
         meta = data.metadata
 
@@ -18,24 +33,36 @@ class HistoricalMedians(BaseStep):
         grouped = df.groupby(series_key_cols)[target]
         df = df.reset_index().set_index(series_key_cols + [date_split_col]).sort_index()
 
-        col_names = {}
-        windows = [prediction_length, 5 * prediction_length, 20 * prediction_length]
-        for window in windows:
-            col_name = 'median_{0}'.format(window)
-            df[col_name] = grouped.rolling(window).median().shift(1)
-            col_names[window] = col_name
+        median_windows = [prediction_length, 5 * prediction_length, 20 * prediction_length]
+        for i_offset in range(self.n_offset_models):
+            for median_win in median_windows:
+                col_name, _ = self.col_name(target, median_win, i_offset)
+                df[col_name] = grouped.rolling(median_win).median().shift((i_offset + 1) * prediction_length)
 
         data.df = df.reset_index().set_index('index')
         to_append = []
         to_append_index = []
-        for window in windows:
-            col_name = col_names[window]
-            to_append_index.append(col_name)
-            to_append.append({
-                'type': ColType.ORDINAL,
-                'derived_from': target,
-                'n_unique': df[col_name].nunique(),
-                'n_na': df[col_name].notnull().sum(),
-                'n_blank': 0
-            })
+        for i_offset in range(self.n_offset_models):
+            for median_win in median_windows:
+                col_name, shared_col_name = self.col_name(target, median_win, i_offset)
+                to_append_index.append(col_name)
+                to_append.append({
+                    'type': ColType.ORDINAL,
+                    'derived_from': target,
+                    'n_unique': df[col_name].nunique(),
+                    'n_na': df[col_name].notnull().sum(),
+                    'n_blank': 0,
+                    'is_lagged_target': True,
+                    'lagged_target_model_offset': i_offset,
+                    'lagged_target_shared_name': shared_col_name
+                })
         data.metadata = meta.append(pd.DataFrame(to_append, index=to_append_index))
+
+    def col_name(self, target, median_win, i_offset):
+        shared_name = '{}_median_{}'.format(target, median_win)
+        if self.n_offset_models == 1:
+            return shared_name, shared_name
+        else:
+            col_name = '{}_offset_{}'.format(shared_name, i_offset)
+            return col_name, shared_name
+

--- a/guacml/preprocessing/feature_generation/historical_medians.py
+++ b/guacml/preprocessing/feature_generation/historical_medians.py
@@ -37,7 +37,9 @@ class HistoricalMedians(BaseStep):
         for i_offset in range(self.n_offset_models):
             for median_win in median_windows:
                 col_name, _ = self.col_name(target, median_win, i_offset)
-                df[col_name] = grouped.rolling(median_win).median().shift((i_offset + 1) * prediction_length)
+                df[col_name] = grouped.rolling(median_win)\
+                                      .median()\
+                                      .shift((i_offset + 1) * prediction_length)
 
         data.df = df.reset_index().set_index('index')
         to_append = []
@@ -65,4 +67,3 @@ class HistoricalMedians(BaseStep):
         else:
             col_name = '{}_offset_{}'.format(shared_name, i_offset)
             return col_name, shared_name
-

--- a/guacml/splitters/date_splitter.py
+++ b/guacml/splitters/date_splitter.py
@@ -11,7 +11,6 @@ class DateSplitter:
         self.frequency = ts_conf['frequency']
         self.n_offset_models = ts_conf['n_offset_models']
 
-
     def holdout_split(self, input):
         """
         In the case of several models to predict different offsets in the future,
@@ -19,7 +18,8 @@ class DateSplitter:
         set we use the full length and predict with many models.
         """
         dates = input[self.date_split_col]
-        split_point = dates.max() - (self.frequency * self.prediction_length * self.n_offset_models)
+        split_point = dates.max() -\
+            (self.frequency * self.prediction_length * self.n_offset_models)
         return input[dates < split_point], input[dates >= split_point]
 
     def cv_splits(self, input):

--- a/guacml/step_tree/hyper_param_optimizer.py
+++ b/guacml/step_tree/hyper_param_optimizer.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 from hyperopt import Trials
 from hyperopt import fmin, tpe
 

--- a/guacml/step_tree/lagged_target_handler.py
+++ b/guacml/step_tree/lagged_target_handler.py
@@ -3,8 +3,8 @@ class LaggedTargetHandler:
     def select_offset_features(df, meta, features, offset):
         """
         When predicting time series many steps into the future, we are using several models for
-        different numbers of steps in the future (offsets), because a model that predicts a month in the
-        future can only use aggregations of the target that are at least a month old.
+        different numbers of steps in the future (offsets), because a model that predicts a month
+        in the future can only use aggregations of the target that are at least a month old.
 
         We only do hyper parameter optimization and feature selection once. For the feature
         selection we map the selected aggregations for different offsets to the same column name.
@@ -20,7 +20,8 @@ class LaggedTargetHandler:
         for idx, lagged_feat_row in lagged_features.iterrows():
             df[lagged_feat_row['lagged_target_shared_name']] = df[lagged_feat_row.name]
 
-        features = non_lagged_features.index.tolist() + lagged_features['lagged_target_shared_name'].tolist()
+        features = non_lagged_features.index.tolist() +\
+            lagged_features['lagged_target_shared_name'].tolist()
         return df, features
 
     @staticmethod
@@ -33,6 +34,3 @@ class LaggedTargetHandler:
         lower = dates.min() + (frequency * (prediction_length * offset))
         upper = dates.min() + (frequency * (prediction_length * (offset + 1) - 1))
         return holdout[dates.between(lower, upper)].index
-
-
-

--- a/guacml/step_tree/lagged_target_handler.py
+++ b/guacml/step_tree/lagged_target_handler.py
@@ -1,0 +1,38 @@
+class LaggedTargetHandler:
+
+    def select_offset_features(df, meta, features, offset):
+        """
+        When predicting time series many steps into the future, we are using several models for
+        different numbers of steps in the future (offsets), because a model that predicts a month in the
+        future can only use aggregations of the target that are at least a month old.
+
+        We only do hyper parameter optimization and feature selection once. For the feature
+        selection we map the selected aggregations for different offsets to the same column name.
+
+        This method selects the appropriate lagged aggregations of the target variable for the
+        specified model offset. It mutates the input DataFrame to store the selected column under
+        the shared name.
+        """
+        feat_meta = meta[meta.index.isin(features)]
+        non_lagged_features = feat_meta[feat_meta['is_lagged_target'].isnull()]
+        lagged_features = feat_meta[feat_meta['lagged_target_model_offset'] == offset]
+
+        for idx, lagged_feat_row in lagged_features.iterrows():
+            df[lagged_feat_row['lagged_target_shared_name']] = df[lagged_feat_row.name]
+
+        features = non_lagged_features.index.tolist() + lagged_features['lagged_target_shared_name'].tolist()
+        return df, features
+
+    @staticmethod
+    def holdout_offset_labels(time_series_config, holdout, offset):
+        date_split_col = time_series_config['date_split_col']
+        prediction_length = time_series_config['prediction_length']
+        frequency = time_series_config['frequency']
+
+        dates = holdout[date_split_col]
+        lower = dates.min() + (frequency * (prediction_length * offset))
+        upper = dates.min() + (frequency * (prediction_length * (offset + 1) - 1))
+        return holdout[dates.between(lower, upper)].index
+
+
+

--- a/guacml/step_tree/model_manager.py
+++ b/guacml/step_tree/model_manager.py
@@ -16,8 +16,12 @@ class ModelManager():
     def execute(self, data):
         features = self.select_features(data.metadata)
         features = features[features != self.target]
-        if self.config['run_time']['is_time_series'] and self.config['run_time']['time_series']['n_offset_models'] > 1:
-            data.df, features = LaggedTargetHandler.select_offset_features(data.df, data.metadata, features, offset=0)
+        if self.config['run_time']['is_time_series'] and\
+           self.config['run_time']['time_series']['n_offset_models'] > 1:
+            data.df, features = LaggedTargetHandler.select_offset_features(data.df,
+                                                                           data.metadata,
+                                                                           features,
+                                                                           offset=0)
 
         model_runner = ModelRunner(self.model, data, self.config, self.logger)
         hp_optimizer = HyperParameterOptimizer(model_runner, features)

--- a/guacml/step_tree/model_result.py
+++ b/guacml/step_tree/model_result.py
@@ -40,6 +40,3 @@ class ModelResult:
             'training error': training_error_str,
             'hyper_params': self.hyper_params
         }
-
-
-

--- a/guacml/step_tree/model_result.py
+++ b/guacml/step_tree/model_result.py
@@ -25,6 +25,11 @@ class ModelResult:
         self.display_hyper_param_runs = display_hp_runs
 
     def to_display_dict(self):
+        if self.training_error is None:
+            training_error_str = ''
+        else:
+            training_error_str = '{:.4g}'.format(self.training_error)
+
         return {
             'n features': len(self.features),
             'holdout error numeric': self.holdout_error,
@@ -32,6 +37,9 @@ class ModelResult:
             'holdout error interval': '{:.4g}, {:.4g}'.format(self.holdout_error_interval[0],
                                                               self.holdout_error_interval[1]),
             'cv error': '{:.4g}'.format(self.cv_error),
-            'training error': '{:.4g}'.format(self.training_error),
+            'training error': training_error_str,
             'hyper_params': self.hyper_params
         }
+
+
+

--- a/guacml/step_tree/model_runner.py
+++ b/guacml/step_tree/model_runner.py
@@ -15,8 +15,9 @@ class ModelRunner():
         self.target = rt_conf['target']
         self.eval_metric = rt_conf['eval_metric']
         self.prediction_range = rt_conf['prediction_range']
-        self.ts_config = rt_conf['time_series']
-        self.n_offset_models = self.ts_config['n_offset_models']
+        if rt_conf['is_time_series']:
+            self.ts_config = rt_conf['time_series']
+            self.n_offset_models = self.ts_config['n_offset_models']
 
         splitter = splitters.create(config)
 

--- a/guacml/step_tree/model_runner.py
+++ b/guacml/step_tree/model_runner.py
@@ -63,7 +63,8 @@ class ModelRunner():
         for train_indices, cv_indices in self.train_and_cv_folds:
             x = self.train_and_cv[features].loc[train_indices]
             y = self.train_and_cv[self.target].loc[train_indices]
-            self.logger.info('Training %s fold #%d on %d rows', self.model.name(), fold_number, x.shape[0])
+            self.logger.info('Training %s fold #%d on %d rows',
+                             self.model.name(), fold_number, x.shape[0])
             self.model.train(x, y, **hyper_params)
 
             prediction = self.model.predict(self.train_and_cv[features].loc[cv_indices])
@@ -88,7 +89,8 @@ class ModelRunner():
     def train_and_predict_with_holdout_model(self, features, hyper_params):
         self.holdout_features = features
         self.holdout_hyper_params = hyper_params
-        self.logger.info('Training holdout model %s on features %s using %s', self.model.name(), features, hyper_params)
+        self.logger.info('Training holdout model %s on features %s using %s',
+                         self.model.name(), features, hyper_params)
 
         self.model.train(
             self.train_and_cv[features],
@@ -110,10 +112,15 @@ class ModelRunner():
 
         for i_offset in range(self.n_offset_models):
             train = self.train_and_cv
-            train, features = LaggedTargetHandler.select_offset_features(train, self.metadata, features, offset=0)
+            train, features = LaggedTargetHandler.select_offset_features(train,
+                                                                         self.metadata,
+                                                                         features,
+                                                                         offset=0)
             self.model.train(train[features], train[self.target], **hyper_params)
 
-            offset_labels = LaggedTargetHandler.holdout_offset_labels(self.ts_config, self.holdout, i_offset)
+            offset_labels = LaggedTargetHandler.holdout_offset_labels(self.ts_config,
+                                                                      self.holdout,
+                                                                      i_offset)
 
             prediction = self.model.predict(self.holdout.loc[offset_labels, features])
             if prediction.isnull().any():

--- a/tests/metrics/test_root_mean_squared_log_error.py
+++ b/tests/metrics/test_root_mean_squared_log_error.py
@@ -25,4 +25,3 @@ class TestRootMeanSquaredLogError(unittest.TestCase):
         rsmle = RootMeanSquaredLogError()
         with self.assertRaises(ValueError):
             rsmle.error(np.ones(1), -np.ones(1))
-

--- a/tests/preprocessing/feature_generation/test_historical_medians.py
+++ b/tests/preprocessing/feature_generation/test_historical_medians.py
@@ -28,4 +28,4 @@ class TestHistoricalMedians(unittest.TestCase):
         self.assertTrue(np.isnan(out.df['count_median_1'].iloc[0]))
         self.assertAlmostEqual(out.df['count_median_1'].iloc[1], 16, delta=1)
 
-    #ToDo: test the metadata
+    # ToDo: test the metadata

--- a/tests/preprocessing/feature_generation/test_historical_medians.py
+++ b/tests/preprocessing/feature_generation/test_historical_medians.py
@@ -13,9 +13,10 @@ class TestHistoricalMedians(unittest.TestCase):
         medians = HistoricalMedians(guac.config)
         out = medians.execute(guac.data)
 
-        self.assertTrue(np.isnan(out.df['median_2'].iloc[0]))
-        self.assertTrue(np.isnan(out.df['median_2'].iloc[1]))
-        self.assertAlmostEqual(out.df['median_2'].iloc[2], 43552444.5, delta=1)
+        self.assertTrue(np.isnan(out.df['Sales_median_2'].iloc[0]))
+        self.assertTrue(np.isnan(out.df['Sales_median_2'].iloc[1]))
+        self.assertTrue(np.isnan(out.df['Sales_median_2'].iloc[2]))
+        self.assertAlmostEqual(out.df['Sales_median_2'].iloc[3], 43552444.5, delta=1)
 
     def test_medians_no_group_keys(self):
         guac = test_util.load_dataset('bike_sharing', target='count')
@@ -24,7 +25,7 @@ class TestHistoricalMedians(unittest.TestCase):
         medians = HistoricalMedians(guac.config)
         out = medians.execute(guac.data)
 
-        self.assertTrue(np.isnan(out.df['median_1'].iloc[0]))
-        self.assertAlmostEqual(out.df['median_1'].iloc[1], 16, delta=1)
+        self.assertTrue(np.isnan(out.df['count_median_1'].iloc[0]))
+        self.assertAlmostEqual(out.df['count_median_1'].iloc[1], 16, delta=1)
 
     #ToDo: test the metadata

--- a/tests/step_tree/test_hyper_parameter_optimizer.py
+++ b/tests/step_tree/test_hyper_parameter_optimizer.py
@@ -1,7 +1,4 @@
 import unittest
-#import numpy as np
-#import pandas as pd
-#import logging
 
 from tests.test_util import load_dataset
 

--- a/tests/test_guac.py
+++ b/tests/test_guac.py
@@ -56,14 +56,16 @@ class TestGuac(unittest.TestCase):
 
     def test_disabled_feature_reduction(self):
         guac = load_dataset()
-        without_feature_reduction = load_dataset(config={'model_manager': {'reduce_features': False}})
+        without_feature_reduction = \
+            load_dataset(config={'model_manager': {'reduce_features': False}})
 
         guac.run(1)
         without_feature_reduction.run(1)
         guac_result = guac.model_results
         wofr_result = without_feature_reduction.model_results
 
-        self.assertLess(len(guac_result['linear_model'].features), len(wofr_result['linear_model'].features))
+        self.assertLess(len(guac_result['linear_model'].features),
+                        len(wofr_result['linear_model'].features))
 
     def test_inplace(self):
         guac = load_dataset(config={'run_time': {'inplace': True}})


### PR DESCRIPTION
When we want to predict x time steps into the future, we can not include the last
x-1 time steps into the median, because they will be unknown for the test set. But we also want to have recent time steps if we don't predict far in the future, as they make prediction better.

Solution: Train several models, some for predicting the closer time steps, some
for the time steps further out. The number of models is called n_offset_models.